### PR TITLE
fix: 이벤트 목록 모달창 외부에서 마우스 스크롤 시 에러 해결

### DIFF
--- a/front/src/components/calendar/EventBar/index.jsx
+++ b/front/src/components/calendar/EventBar/index.jsx
@@ -1,24 +1,23 @@
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
-import { useSelector } from 'react-redux';
 import { EVENT_URL } from '../../../constants/api';
 import { EventDetailModalContext } from '../../../context/EventModalContext';
-import { calendarByEventIdSelector } from '../../../store/selectors/calendars';
-import { eventSelector } from '../../../store/selectors/events';
 import axios from '../../../utils/token';
 import styles from './style.module.css';
 
 const Index = ({
-  eventBar,
+  event,
+  calendarColor,
+  eventBarScale,
   left = false,
   right = false,
   outerRight = false,
   handleEventDetailMadal = () => {},
 }) => {
-  const event = useSelector(state => eventSelector(state, eventBar?.id));
-  const calendar = useSelector(state =>
-    calendarByEventIdSelector(state, event),
-  );
+  // const event = useSelector(state => eventSelector(state, eventBar?.id));
+  // const calendar = useSelector(state =>
+  //   calendarByEventIdSelector(state, event),
+  // );
 
   const { setModalData: setEventDetailModalData } = useContext(
     EventDetailModalContext,
@@ -26,12 +25,14 @@ const Index = ({
 
   const eventBarStyle = {
     container: {
-      width: `calc(100% * ${eventBar?.scale} + ${eventBar?.scale}px - 5px)`,
+      width: `calc(100% * ${eventBarScale} + ${eventBarScale}px - 5px)`,
     },
     main: {
-      background: `linear-gradient(to right, ${calendar?.color} 5px, ${event?.color} 5px)`,
+      background: `linear-gradient(to right, ${calendarColor} 5px, ${
+        event?.color || calendarColor
+      } 5px)`,
     },
-    left: { borderRightColor: calendar?.color },
+    left: { borderRightColor: calendarColor },
     right: { borderLeftColor: event?.color },
   };
 
@@ -55,7 +56,7 @@ const Index = ({
     }));
   }
 
-  if (!eventBar || !eventBar.scale) {
+  if (!eventBarScale) {
     return <div className={styles.empty_event_bar} />;
   }
 
@@ -68,7 +69,7 @@ const Index = ({
       {left && <div className={styles.event_left} style={eventBarStyle.left} />}
 
       <div className={styles.event_bar} style={eventBarStyle.main}>
-        <em>{event?.name || eventBar.name || '(제목 없음)'}</em>
+        <em>{event?.name || '(제목 없음)'}</em>
       </div>
 
       {right && (
@@ -84,7 +85,9 @@ const Index = ({
 };
 
 Index.propTypes = {
-  eventBar: PropTypes.object,
+  event: PropTypes.object,
+  calendarColor: PropTypes.string,
+  eventBarScale: PropTypes.number,
   left: PropTypes.bool,
   right: PropTypes.bool,
   outerRight: PropTypes.bool,

--- a/front/src/components/calendar/EventBar/index.jsx
+++ b/front/src/components/calendar/EventBar/index.jsx
@@ -8,7 +8,7 @@ import styles from './style.module.css';
 const Index = ({
   event,
   calendarColor,
-  eventBarScale,
+  eventBar,
   left = false,
   right = false,
   outerRight = false,
@@ -25,7 +25,7 @@ const Index = ({
 
   const eventBarStyle = {
     container: {
-      width: `calc(100% * ${eventBarScale} + ${eventBarScale}px - 5px)`,
+      width: `calc(100% * ${eventBar?.scale} + ${eventBar?.scale}px - 5px)`,
     },
     main: {
       background: `linear-gradient(to right, ${calendarColor} 5px, ${
@@ -56,7 +56,7 @@ const Index = ({
     }));
   }
 
-  if (!eventBarScale) {
+  if (!eventBar || !eventBar.scale) {
     return <div className={styles.empty_event_bar} />;
   }
 
@@ -69,7 +69,7 @@ const Index = ({
       {left && <div className={styles.event_left} style={eventBarStyle.left} />}
 
       <div className={styles.event_bar} style={eventBarStyle.main}>
-        <em>{event?.name || '(제목 없음)'}</em>
+        <em>{event?.name || eventBar.name || '(제목 없음)'}</em>
       </div>
 
       {right && (
@@ -87,7 +87,7 @@ const Index = ({
 Index.propTypes = {
   event: PropTypes.object,
   calendarColor: PropTypes.string,
-  eventBarScale: PropTypes.number,
+  eventBar: PropTypes.object,
   left: PropTypes.bool,
   right: PropTypes.bool,
   outerRight: PropTypes.bool,

--- a/front/src/components/calendar/month/CalendarBody/Date/EventList/index.jsx
+++ b/front/src/components/calendar/month/CalendarBody/Date/EventList/index.jsx
@@ -5,34 +5,43 @@ import EventBar from '../../../../EventBar';
 import ReadMoreTitle from './ReadMoreTitle';
 
 import { useSelector } from 'react-redux';
-import { eventsByDateSelector } from '../../../../../../store/selectors/events';
+import {
+  eventsByDateSelector,
+  eventsByEventIdsSelector,
+} from '../../../../../../store/selectors/events';
 import {
   EventDetailModalContext,
   EventListModalContext,
 } from '../../../../../../context/EventModalContext';
+import { calendarByEventIdsSelector } from '../../../../../../store/selectors/calendars';
 
 const Index = ({ date, maxHeight }) => {
-  const events = useSelector(state => eventsByDateSelector(state, date));
   const { showModal: showEventListModal, hideModal: hideEventListModal } =
     useContext(EventListModalContext);
   const { showModal: showEventDetailModal, hideModal: hideEventDetailModal } =
     useContext(EventDetailModalContext);
-
   const $eventList = useRef();
-  if (!events) return;
+
+  const eventBars = useSelector(state => eventsByDateSelector(state, date));
+  const events = useSelector(state =>
+    eventsByEventIdsSelector(state, eventBars || []),
+  );
+  const calendars = useSelector(state =>
+    calendarByEventIdsSelector(state, events || []),
+  );
+
+  if (!eventBars) return;
 
   const countEventBar = Math.floor(maxHeight / 30);
-  const previewEvent = countEventBar ? events.slice(0, countEventBar) : [];
-  const restEvent = events.slice(countEventBar);
+  const previewEvent = countEventBar ? eventBars.slice(0, countEventBar) : [];
+  const restEvent = eventBars.slice(countEventBar);
 
   function clickReadMore(e) {
     const { top, left } = $eventList.current.getBoundingClientRect();
     const minLeft = window.innerWidth - 250;
     showEventListModal({
       date,
-      events: events
-        .filter(event => event)
-        .map(event => ({ ...event, scale: 1 })),
+      events: events.filter(event => event),
       style: {
         top: top - 35,
         left: minLeft < left ? minLeft : left,
@@ -56,10 +65,12 @@ const Index = ({ date, maxHeight }) => {
       ref={$eventList}
       data-drag-date={date.time}
     >
-      {previewEvent.slice(0, countEventBar).map((event, index) => (
+      {previewEvent.slice(0, countEventBar).map((eventBar, index) => (
         <EventBar
           key={index}
-          eventBar={event}
+          event={events[index]}
+          calendarColor={calendars[index]?.color}
+          eventBarScale={eventBar?.scale}
           handleEventDetailMadal={handleEventDetailMadal}
         />
       ))}

--- a/front/src/components/calendar/month/CalendarBody/Date/EventList/index.jsx
+++ b/front/src/components/calendar/month/CalendarBody/Date/EventList/index.jsx
@@ -70,7 +70,7 @@ const Index = ({ date, maxHeight }) => {
           key={index}
           event={events[index]}
           calendarColor={calendars[index]?.color}
-          eventBarScale={eventBar?.scale}
+          eventBar={eventBar}
           handleEventDetailMadal={handleEventDetailMadal}
         />
       ))}

--- a/front/src/components/calendar/month/CalendarBody/Date/NewEvent/index.jsx
+++ b/front/src/components/calendar/month/CalendarBody/Date/NewEvent/index.jsx
@@ -28,7 +28,7 @@ const Index = ({ dateTime }) => {
   if (!eventBar) return;
   return (
     <div className={styles.new_event_bar} ref={$eventBarParent}>
-      <EventBar eventBar={eventBar} />
+      <EventBar eventBarScale={eventBar.scale} />
     </div>
   );
 };

--- a/front/src/components/calendar/month/CalendarBody/Date/NewEvent/index.jsx
+++ b/front/src/components/calendar/month/CalendarBody/Date/NewEvent/index.jsx
@@ -28,7 +28,7 @@ const Index = ({ dateTime }) => {
   if (!eventBar) return;
   return (
     <div className={styles.new_event_bar} ref={$eventBarParent}>
-      <EventBar eventBarScale={eventBar.scale} />
+      <EventBar eventBar={eventBar} />
     </div>
   );
 };

--- a/front/src/components/calendar/month/CalendarBody/Date/index.jsx
+++ b/front/src/components/calendar/month/CalendarBody/Date/index.jsx
@@ -41,13 +41,14 @@ const Index = ({ date }) => {
 };
 
 function getTitleDate(date) {
-  return date.date === 1 ? `${date.month}월 1일` : date.date;
+  return !isSameDate(date, new Moment()) && date.date === 1
+    ? `${date.month}월 1일`
+    : date.date;
 }
 
 function initClassName(date) {
-  let className = styles.calendar_td + ' ';
-  if (isSameDate(date, new Moment())) className += styles.calendar_today;
-
+  const className = styles.calendar_td + ' ';
+  if (isSameDate(date, new Moment())) return className + styles.calendar_today;
   return className;
 }
 

--- a/front/src/components/common/CheckBox/index.jsx
+++ b/front/src/components/common/CheckBox/index.jsx
@@ -4,15 +4,15 @@ import PropTypes from 'prop-types';
 
 const Index = ({
   children,
-  onChange,
+  onChange = () => {},
   defaultChecked = true,
   color = '#1a73e8',
 }) => {
   function handleCheckBox(e) {
-    onChange(e);
     const { background, border } = checkBoxStyle(e.target.checked);
     e.target.style.background = background;
     e.target.style.border = border;
+    onChange(e);
   }
 
   function checkBoxStyle(checked) {

--- a/front/src/components/common/CheckBox/style.module.css
+++ b/front/src/components/common/CheckBox/style.module.css
@@ -1,4 +1,4 @@
-.checkbox { display: flex; align-items: center; width: 80%; -webkit-touch-callout: none; -webkit-user-select: none; -khtml-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; } 
+.checkbox { display: flex; align-items: center;  -webkit-touch-callout: none; -webkit-user-select: none; -khtml-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; } 
 .checkbox input { -moz-appearance:none; -webkit-appearance:none; -o-appearance:none; outline: none; content: none; border-radius: 3px; width: 18px; height: 18px; margin-right: 10px; transition: all .4s; } 
 .checkbox p { text-align: left; } 
 

--- a/front/src/modal/component/CreateEventModal/index.jsx
+++ b/front/src/modal/component/CreateEventModal/index.jsx
@@ -141,7 +141,7 @@ const Index = ({ hideModal, style }) => {
             <div>
               <div />
               <div>
-                <CheckBox>
+                <CheckBox onClick={() => {}}>
                   <h3>종일</h3>
                 </CheckBox>
               </div>

--- a/front/src/modal/component/EventDetailModal/EventMemberList/index.jsx
+++ b/front/src/modal/component/EventDetailModal/EventMemberList/index.jsx
@@ -51,8 +51,8 @@ const Index = ({ eventMembers }) => {
         <div>
           {eventMembers.map(member => (
             <div key={member.id} className={styles.user_info}>
-              <em className={styles.user_profile}>
-                {member.email[0]}
+              <div className={styles.user_profile}>
+                <img src={member.ProfileImages[0].src} alt="profile" />
                 {member.EventMember.state ? (
                   <FontAwesomeIcon
                     className={`${styles.user_state} ${
@@ -64,8 +64,7 @@ const Index = ({ eventMembers }) => {
                     }
                   />
                 ) : null}
-              </em>
-
+              </div>
               <h3>{member.email}</h3>
             </div>
           ))}

--- a/front/src/modal/component/EventDetailModal/EventMemberList/style.module.css
+++ b/front/src/modal/component/EventDetailModal/EventMemberList/style.module.css
@@ -1,6 +1,8 @@
 .user_info { display: flex; margin-bottom: 10px; } 
-.user_info .user_profile { position: relative; display: flex; align-items: center; justify-content: center; border-radius: 100%; background: orange; width: 25px; height: 25px; color: white; margin-right: 12px; } 
-.user_info .user_state { border-radius: 100%; background: gainsboro; color: #515151; padding: 2px; width: 10px; height: 10px; border: 1px solid white; position: absolute; left: 18px; top: 9px } 
+.user_info .user_profile { position: relative; margin-right: 15px; } 
+.user_info .user_profile img { position: relative; border-radius: 100%; background: white; width: 25px; height: 25px; color: white;  } 
+.user_info .user_state { border-radius: 100%; background: gainsboro; color: #515151; padding: 2px; width: 10px; height: 10px; border: 1px solid white; position: absolute; left:18px; top: 11px; } 
+
 .user_info .accept { background: #b4eecf; color: #046a1f; } 
 .user_info .refuse { background: #ffcece; color: #da1515; } 
 .user_info .toBeDetermined { background: gainsboro; color: #3b3b3b; } 

--- a/front/src/modal/component/EventDetailModal/style.module.css
+++ b/front/src/modal/component/EventDetailModal/style.module.css
@@ -12,7 +12,7 @@
 
 .modal_body h1 { font-size: 20px; font-weight: 500; color: #6b6b6b; } 
 .modal_body h3 { font-size: 15px; font-weight: 400; color: #6b6b6b; } 
-.modal_body p { font-size: 13px; font-weight: 300; } 
+.modal_body p { font-size: 13px; font-weight: 300; color: #737373; } 
 
 .event_color { width: 14px !important; height: 14px !important; border-radius: 3px; margin-left: 24px !important; margin-right: 23px !important; } 
 

--- a/front/src/modal/component/EventListModal/EventContainer/index.jsx
+++ b/front/src/modal/component/EventListModal/EventContainer/index.jsx
@@ -20,7 +20,7 @@ const Index = ({ event, calendarColor, date }) => {
 
   return (
     <EventBar
-      eventBarScale={1}
+      eventBar={{ scale: 1 }}
       event={event}
       calendarColor={calendarColor}
       left={new Moment(new Date(startTime)).resetTime().time !== date.time}

--- a/front/src/modal/component/EventListModal/EventContainer/index.jsx
+++ b/front/src/modal/component/EventListModal/EventContainer/index.jsx
@@ -3,14 +3,10 @@ import PropTypes from 'prop-types';
 
 import Moment from '../../../../utils/moment';
 import EventBar from '../../../../components/calendar/EventBar';
-import { useSelector } from 'react-redux';
-import { eventSelector } from '../../../../store/selectors/events';
 import { EventDetailModalContext } from '../../../../context/EventModalContext';
 
-const Index = ({ event, date }) => {
-  const { startTime, endTime } = useSelector(state =>
-    eventSelector(state, event.id),
-  );
+const Index = ({ event, calendarColor, date }) => {
+  const { startTime, endTime } = event;
   const { showModal: showEventDetailModal } = useContext(
     EventDetailModalContext,
   );
@@ -24,7 +20,9 @@ const Index = ({ event, date }) => {
 
   return (
     <EventBar
-      eventBar={event}
+      eventBarScale={1}
+      event={event}
+      calendarColor={calendarColor}
       left={new Moment(new Date(startTime)).resetTime().time !== date.time}
       right={new Moment(new Date(endTime)).resetTime().time !== date.time}
       outerRight={true}
@@ -35,6 +33,7 @@ const Index = ({ event, date }) => {
 
 Index.propTypes = {
   event: PropTypes.object,
+  calendarColor: PropTypes.string,
   date: PropTypes.object,
 };
 

--- a/front/src/modal/component/EventListModal/index.jsx
+++ b/front/src/modal/component/EventListModal/index.jsx
@@ -3,9 +3,15 @@ import styles from './style.module.css';
 import PropTypes from 'prop-types';
 import Modal from '../../../components/common/Modal';
 import EventContainer from './EventContainer';
+import { useSelector } from 'react-redux';
+import { calendarByEventIdsSelector } from '../../../store/selectors/calendars';
 
 const Index = ({ modalData, hideModal }) => {
   const { date, events, style } = modalData;
+
+  const calendars = useSelector(state =>
+    calendarByEventIdsSelector(state, events || []),
+  );
 
   return (
     <Modal hideModal={hideModal} style={style} isCloseButtom={true}>
@@ -13,8 +19,13 @@ const Index = ({ modalData, hideModal }) => {
         <strong>{date.weekDay}</strong>
         <h1>{date.date}</h1>
         {events?.length ? (
-          events.map(event => (
-            <EventContainer key={event.id} event={event} date={date} />
+          events.map((event, index) => (
+            <EventContainer
+              key={event.id}
+              event={event}
+              calendarColor={calendars[index].color}
+              date={date}
+            />
           ))
         ) : (
           <p>이 날짜에는 예정된 일정이 없습니다.</p>

--- a/front/src/store/selectors/calendars.js
+++ b/front/src/store/selectors/calendars.js
@@ -31,3 +31,13 @@ export const calendarByEventIdSelector = createSelector(
   [state => state, (_, event) => event?.PrivateCalendarId || event?.CalendarId],
   (state, calendarId) => selectCalendarById(state, calendarId),
 );
+
+export const calendarByEventIdsSelector = createSelector(
+  [
+    state => state,
+    (_, events) =>
+      events.map(event => event?.PrivateCalendarId || event?.CalendarId),
+  ],
+  (state, calendarIds) =>
+    calendarIds.map(calendarId => selectCalendarById(state, calendarId)),
+);

--- a/front/src/store/selectors/events.js
+++ b/front/src/store/selectors/events.js
@@ -1,9 +1,8 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { eventsAdapter } from '../events';
 
-export const { selectById: selectEventById } = eventsAdapter.getSelectors(
-  state => state.events,
-);
+export const { selectById: selectEventById, selectAll: allEventSelector } =
+  eventsAdapter.getSelectors(state => state.events);
 
 export const eventsByDateSelector = createSelector(
   [state => state.events.byDate, (_, date) => date.time],
@@ -13,4 +12,10 @@ export const eventsByDateSelector = createSelector(
 export const eventSelector = createSelector(
   [state => state, (_, eventId) => eventId],
   (state, eventId) => (eventId ? selectEventById(state, eventId) : null),
+);
+
+export const eventsByEventIdsSelector = createSelector(
+  [state => state, (_, events) => events],
+  (state, events) =>
+    events.map(event => (event?.id ? selectEventById(state, event.id) : null)),
 );


### PR DESCRIPTION
## ⭐ Point <!-- 구현한 기능 혹은 목표에 대한 간략한 설명 -->
월 단위 캘린더에서 이벤트 목록 모달창이 활성화된 상태에서 월 이동 시(마우스 스크롤), 모달창 그대로 유지

## 👨‍💻 작업 내용 <!-- 추가 설명이 필요한 경우 기입 -->
- 이벤트 목록 모달창에 event와 calendar 데이터 전달 (selector 제거)
- 이벤트 참석자의 프로필 추가


<br/>

#### ⚡ Related Issues <!-- 관련된 이슈 번호 기입 -->
Closes #177
