### PR TITLE
feat: 이벤트 생성 입력 데이터 제한 설정 및 마우스 드래그로 이동 기능 구현 (#249, #257)

### DIFF
--- a/front/src/components/alert/CustomAlertOfAllDay/index.jsx
+++ b/front/src/components/alert/CustomAlertOfAllDay/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import styles from './style.module.css';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -19,6 +19,8 @@ const Index = React.forwardRef((props, ref) => {
   const [sendType, setSendType] = useState('알림');
   const [dateType, setDateType] = useState('일');
   const [dateNumber, setDateNumber] = useState(1);
+  const dateNumberRef = useRef();
+  const [dateNumberErorr, setDateNumberError] = useState('');
   const [time, setTime] = useState(new Moment().setHour(9).time);
 
   useImperativeHandle(ref, () => ({
@@ -27,6 +29,13 @@ const Index = React.forwardRef((props, ref) => {
       time: dateNumber,
       hour: new Date(time).getHours(),
       minute: new Date(time).getMinutes(),
+    },
+    checkAlertTime: () => {
+      if (!checkDateNumber(dateNumber)) {
+        dateNumberRef.current.focus();
+        return false;
+      }
+      return true;
     },
   }));
 
@@ -38,9 +47,24 @@ const Index = React.forwardRef((props, ref) => {
 
   function onChangeNumber(e) {
     const number = +e.target.value;
-    if (dateType === '일' && (number < 0 || number > 28)) return;
-    if (dateType === '주' && (number < 0 || number > 4)) return;
+    checkDateNumber(number);
     setDateNumber(+e.target.value);
+  }
+
+  function checkDateNumber(number) {
+    if (dateType === '분' && (number < 0 || number > 40320)) {
+      setDateNumberError('0분에서 40320분 사이여야 합니다.');
+    } else if (dateType === '시간' && (number < 0 || number > 672)) {
+      setDateNumberError('0시간에서 672시간 사이여야 합니다.');
+    } else if (dateType === '일' && (number < 0 || number > 28)) {
+      setDateNumberError('0일에서 28일 사이여야 합니다.');
+    } else if (dateType === '주' && (number < 0 || number > 4)) {
+      setDateNumberError('0주에서 4주 사이여야 합니다.');
+    } else {
+      setDateNumberError('');
+      return true;
+    }
+    return false;
   }
 
   return (
@@ -72,12 +96,26 @@ const Index = React.forwardRef((props, ref) => {
         )}
       </div>
 
-      <Input
-        type="number"
-        value={dateNumber}
-        className={styles.alert_input_number}
-        onChange={onChangeNumber}
-      />
+      <div className={styles.alert_input_container}>
+        <Input
+          type="number"
+          value={dateNumber}
+          className={`${styles.alert_input_number} ${
+            dateNumberErorr ? styles.error_input : ''
+          }`}
+          onChange={onChangeNumber}
+          onFocus={() => checkDateNumber(dateNumber)}
+          onBlur={() => setDateNumberError('')}
+          ref={dateNumberRef}
+        />
+
+        {dateNumberErorr && (
+          <div className={styles.error_message}>
+            <div className={styles.square} />
+            <p>{dateNumberErorr}</p>
+          </div>
+        )}
+      </div>
 
       <div
         className={styles.date_modal_container}

--- a/front/src/components/alert/CustomAlertOfAllDay/index.jsx
+++ b/front/src/components/alert/CustomAlertOfAllDay/index.jsx
@@ -18,13 +18,13 @@ const Index = React.forwardRef((props, ref) => {
 
   const [sendType, setSendType] = useState('알림');
   const [dateType, setDateType] = useState('일');
-  const [number, setNumber] = useState(1);
+  const [dateNumber, setDateNumber] = useState(1);
   const [time, setTime] = useState(new Moment().setHour(9).time);
 
   useImperativeHandle(ref, () => ({
     alert: {
       type: dateType,
-      time: number,
+      time: dateNumber,
       hour: new Date(time).getHours(),
       minute: new Date(time).getMinutes(),
     },
@@ -34,6 +34,13 @@ const Index = React.forwardRef((props, ref) => {
     sendTypeModal.hideModal();
     dateTypeModal.hideModal();
     timeListModal.hideModal();
+  }
+
+  function onChangeNumber(e) {
+    const number = +e.target.value;
+    if (dateType === '일' && (number < 0 || number > 28)) return;
+    if (dateType === '주' && (number < 0 || number > 4)) return;
+    setDateNumber(+e.target.value);
   }
 
   return (
@@ -51,6 +58,7 @@ const Index = React.forwardRef((props, ref) => {
       >
         <h3>{sendType}</h3>
         <FontAwesomeIcon icon={faCaretDown} />
+
         {sendTypeModal.isModalShown && (
           <ListModal
             hideModal={sendTypeModal.hideModal}
@@ -63,12 +71,14 @@ const Index = React.forwardRef((props, ref) => {
           />
         )}
       </div>
+
       <Input
         type="number"
-        value={number}
+        value={dateNumber}
         className={styles.alert_input_number}
-        onChange={e => setNumber(+e.target.value)}
+        onChange={onChangeNumber}
       />
+
       <div
         className={styles.date_modal_container}
         onClick={e => {
@@ -82,12 +92,14 @@ const Index = React.forwardRef((props, ref) => {
       >
         <h3>{dateType}</h3>
         <FontAwesomeIcon icon={faCaretDown} />
+
         {dateTypeModal.isModalShown && (
           <ListModal
             hideModal={dateTypeModal.hideModal}
             modalData={dateTypeModal.modalData}
             onClickItem={e => {
               setDateType(e.target.innerText);
+              setDateNumber(1);
               dateTypeModal.hideModal();
               e.stopPropagation();
             }}
@@ -95,6 +107,7 @@ const Index = React.forwardRef((props, ref) => {
         )}
       </div>
       <h3>전</h3>
+
       <div
         className={styles.time_modal_container}
         onClick={e => {
@@ -111,6 +124,7 @@ const Index = React.forwardRef((props, ref) => {
           value={new Moment(time).toTimeString()}
           className={styles.alert_input}
         />
+
         {timeListModal.isModalShown && (
           <TimeListModal
             hideModal={timeListModal.hideModal}

--- a/front/src/components/alert/CustomAlertOfAllDay/style.module.css
+++ b/front/src/components/alert/CustomAlertOfAllDay/style.module.css
@@ -8,11 +8,18 @@
 .alert_input input { background: #f1f3f4; font-size: 14px; } 
 .alert_input hr { background: transparent; } 
 
-.alert_input_number { width: 50px !important; } 
+.alert_input_container { position:relative; padding: 0px !important; height: 36px !important;} 
+.square { position: absolute; top: -14px; left: 8px; width: 0; height: 0; border-bottom: 7px solid #454545; border-top: 7px solid transparent; border-left: 6px solid transparent; border-right: 6px solid transparent; } 
+.error_message { font-size:12px; position: absolute; transition: all 0.5s;  top: 45px; left: 0px; width: 150px; z-index: 2; background: #454545; color: white; padding: 6px 10px; } 
+
+.alert_input_number { width: 50px !important; height: 36px !important; font-size: 14px; padding:0px 8px; margin-right: 0px; } 
 .alert_input_number input { background: #f1f3f4; font-size: 14px; } 
 .alert_input_number input::-webkit-outer-spin-button, 
 .alert_input_number input::-webkit-inner-spin-button { padding: 10px 0px; height: 5px !important; } 
 .alert_input_number hr { background: transparent; } 
+
+.error_input { background: #ffe7e7 !important; } 
+.error_input input { background: #ffe7e7; } 
 
 .send_modal_container, .date_modal_container { position: relative } 
 .send_modal_container > div, .date_modal_container > div { position: absolute; top: -7px; left: 0; box-shadow: 1px 4px 13px 0px rgb(0, 0, 0, 0.4); } 

--- a/front/src/components/alert/CustomAlertOfAllDay/style.module.css
+++ b/front/src/components/alert/CustomAlertOfAllDay/style.module.css
@@ -8,9 +8,9 @@
 .alert_input input { background: #f1f3f4; font-size: 14px; } 
 .alert_input hr { background: transparent; } 
 
-.alert_input_container { position:relative; padding: 0px !important; height: 36px !important;} 
+.alert_input_container { position:relative; padding: 0px !important; height: 36px !important; transition: all 0.5s;} 
 .square { position: absolute; top: -14px; left: 8px; width: 0; height: 0; border-bottom: 7px solid #454545; border-top: 7px solid transparent; border-left: 6px solid transparent; border-right: 6px solid transparent; } 
-.error_message { font-size:12px; position: absolute; transition: all 0.5s;  top: 45px; left: 0px; width: 150px; z-index: 2; background: #454545; color: white; padding: 6px 10px; } 
+.error_message { width: 160px !important; font-size:12px; position: absolute;  word-break: break-all; top: 45px; left: 0px; width: 150px; z-index: 2; background: #454545; color: white; padding: 8px 10px; } 
 
 .alert_input_number { width: 50px !important; height: 36px !important; font-size: 14px; padding:0px 8px; margin-right: 0px; } 
 .alert_input_number input { background: #f1f3f4; font-size: 14px; } 

--- a/front/src/components/alert/CustomAlertOfNotAllDay/style.module.css
+++ b/front/src/components/alert/CustomAlertOfNotAllDay/style.module.css
@@ -1,14 +1,21 @@
-.alert_options { display: flex; justify-content: left;} 
-.alert_options > h3 { font-size: 14px; margin-right: 0px; padding: 8px; padding-left: 0px; } 
-.alert_options > div { height: 20px; display: flex; align-items: center; background: #f1f3f4; margin-right: 8px; padding: 8px; border-radius: 3px; } 
+.alert_options { display: flex; justify-content: left; } 
+.send_modal_container, .date_modal_container { font-size: 14px; margin-right: 0px; padding: 8px; padding-left: 0px; } 
+.alert_options > div, .alert_input_number { height: 20px; display: flex; align-items: center; background: #f1f3f4; margin-right: 8px; padding: 8px; border-radius: 3px; } 
 .alert_options > div > svg { margin-left: 8px; color: rgb(69, 69, 69); } 
 
+.alert_input_container { position:relative; padding: 0px !important; height: 36px !important;} 
 
-.alert_input {width: 50px;}
-.alert_input input { background: #f1f3f4; font-size: 14px; } 
-.alert_input input[type="number"]::-webkit-outer-spin-button, 
-.alert_input input[type="number"]::-webkit-inner-spin-button { padding: 10px 0px; height: 5px !important; } 
-.alert_input hr {background: transparent;}
+.square { position: absolute; top: -14px; left: 8px; width: 0; height: 0; border-bottom: 7px solid #454545; border-top: 7px solid transparent; border-left: 6px solid transparent; border-right: 6px solid transparent; } 
+.error_message { font-size:12px; position: absolute; transition: all 0.5s;  top: 45px; left: 0px; width: 150px; z-index: 2; background: #454545; color: white; padding: 6px 10px; } 
+
+.alert_input_number { width: 50px !important; height: 36px !important; font-size: 14px; padding:0px 8px; margin-right: 0px; } 
+.alert_input_number input { background: #f1f3f4; font-size: 14px; } 
+.alert_input_number input::-webkit-outer-spin-button, 
+.alert_input_number input::-webkit-inner-spin-button { padding: 10px 0px; height: 5px !important; } 
+.alert_input_number hr { background: transparent; } 
+
+.error_input { background: #ffe7e7 !important; } 
+.error_input input { background: #ffe7e7; } 
 
 .send_modal_container, .date_modal_container { position: relative } 
 .send_modal_container > div, .date_modal_container > div { position: absolute; top: -7px; left: 0; box-shadow: 1px 4px 13px 0px rgb(0, 0, 0, 0.4); } 

--- a/front/src/components/alert/CustomAlertOfNotAllDay/style.module.css
+++ b/front/src/components/alert/CustomAlertOfNotAllDay/style.module.css
@@ -3,10 +3,9 @@
 .alert_options > div, .alert_input_number { height: 20px; display: flex; align-items: center; background: #f1f3f4; margin-right: 8px; padding: 8px; border-radius: 3px; } 
 .alert_options > div > svg { margin-left: 8px; color: rgb(69, 69, 69); } 
 
-.alert_input_container { position:relative; padding: 0px !important; height: 36px !important;} 
-
+.alert_input_container { position:relative; padding: 0px !important; height: 36px !important; transition: all 0.5s;} 
 .square { position: absolute; top: -14px; left: 8px; width: 0; height: 0; border-bottom: 7px solid #454545; border-top: 7px solid transparent; border-left: 6px solid transparent; border-right: 6px solid transparent; } 
-.error_message { font-size:12px; position: absolute; transition: all 0.5s;  top: 45px; left: 0px; width: 150px; z-index: 2; background: #454545; color: white; padding: 6px 10px; } 
+.error_message { width: 160px !important; font-size:12px; position: absolute;  word-break: break-all; top: 45px; left: 0px; width: 150px; z-index: 2; background: #454545; color: white; padding: 8px 10px; } 
 
 .alert_input_number { width: 50px !important; height: 36px !important; font-size: 14px; padding:0px 8px; margin-right: 0px; } 
 .alert_input_number input { background: #f1f3f4; font-size: 14px; } 

--- a/front/src/components/calendar/EventBar/index.jsx
+++ b/front/src/components/calendar/EventBar/index.jsx
@@ -30,7 +30,6 @@ const Index = ({
     const { top, left } = e.currentTarget.getBoundingClientRect();
 
     const { data } = await getEventDetail(event);
-    console.log(data, event);
     const { EventMembers, EventHost, realTimeAlert } = data;
     const alerts =
       realTimeAlert?.map(alert => {

--- a/front/src/components/common/Input/index.jsx
+++ b/front/src/components/common/Input/index.jsx
@@ -1,48 +1,64 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useState } from 'react';
 import styles from './style.module.css';
 import PropTypes from 'prop-types';
+import { useImperativeHandle } from 'react';
 
-const Index = ({
-  type,
-  defaultValue = null,
-  value = null,
-  autoFocus = false,
-  placeholder,
-  onChange = () => {},
-  onBlur = () => {},
-  onKeyDown = () => {},
-  className = '',
-}) => {
-  const [isInputFocus, setInputFocus] = useState(false);
+const Index = React.forwardRef(
+  (
+    {
+      type,
+      defaultValue = null,
+      value = null,
+      autoFocus = false,
+      placeholder,
+      onChange = () => {},
+      onBlur = () => {},
+      onFocus = () => {},
+      onKeyDown = () => {},
+      className = '',
+    },
+    ref,
+  ) => {
+    const [isInputFocus, setInputFocus] = useState(false);
 
-  function handleBlurEvent(e) {
-    onBlur(e);
-    setInputFocus(false);
-  }
+    function handleBlurEvent(e) {
+      onBlur(e);
+      setInputFocus(false);
+    }
 
-  return (
-    <div className={`${styles.input_container} ${className}`}>
-      <input
-        type={type}
-        autoFocus={autoFocus}
-        placeholder={placeholder}
-        onFocus={() => setInputFocus(true)}
-        onBlur={handleBlurEvent}
-        onKeyDown={onKeyDown}
-        {...(defaultValue !== null ? { defaultValue } : { onChange })}
-        {...(value !== null && { value })}
-      />
-      <hr className={`${styles.input_line} ${styles.line_active}`} />
-      <hr
-        className={`${styles.input_line} ${
-          isInputFocus ? styles.line_active : styles.line_hide
-        }`}
-      />
-    </div>
-  );
-};
+    const inputRef = useRef();
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current.focus(),
+    }));
 
+    return (
+      <div className={`${styles.input_container} ${className}`}>
+        <input
+          ref={inputRef}
+          type={type}
+          autoFocus={autoFocus}
+          placeholder={placeholder}
+          onFocus={e => {
+            setInputFocus(true);
+            onFocus(e);
+          }}
+          onBlur={handleBlurEvent}
+          onKeyDown={onKeyDown}
+          {...(defaultValue !== null ? { defaultValue } : { onChange })}
+          {...(value !== null && { value })}
+        />
+        <hr className={`${styles.input_line} ${styles.line_active}`} />
+        <hr
+          className={`${styles.input_line} ${
+            isInputFocus ? styles.line_active : styles.line_hide
+          }`}
+        />
+      </div>
+    );
+  },
+);
+Index.displayName = 'Input';
 Index.propTypes = {
   type: PropTypes.string,
   defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -51,6 +67,7 @@ Index.propTypes = {
   placeholder: PropTypes.string,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
   onKeyDown: PropTypes.func,
   className: PropTypes.string,
 };

--- a/front/src/components/common/Line/style.module.css
+++ b/front/src/components/common/Line/style.module.css
@@ -1,1 +1,1 @@
-.line { position: relative; background: #e8e8e8; height: 1px !important; width: calc(100% + 16px); left: -8px; z-index: 2; margin-bottom: 10px; } 
+.line { position: relative; background: #e8e8e8; height: 1px !important; width: calc(100% + 16px) !important; left: -8px; z-index: 2; margin-bottom: 10px; } 

--- a/front/src/components/common/Modal/index.jsx
+++ b/front/src/components/common/Modal/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './style.module.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
@@ -6,6 +6,9 @@ import PropTypes from 'prop-types';
 import Tooltip from '../Tooltip';
 import { useEffect } from 'react';
 import { useRef } from 'react';
+import { throttle } from '../../../utils/delay';
+import { useCallback } from 'react';
+import { useMemo } from 'react';
 
 const Index = ({
   children,
@@ -15,7 +18,23 @@ const Index = ({
   isBackground = false,
   backgroundColor = 'transform',
 }) => {
-  const $modal = useRef();
+  const modalRef = useRef();
+  const modalBackgroundRef = useRef();
+
+  const [isMouseDown, setMouseDown] = useState(false);
+  const pos = useMemo(() => ({ x: 0, y: 0 }), []);
+  const moveModal = useCallback(e => {
+    if (e.pageY === pos.y && e.pageX === pos.x) return;
+    throttle(() => {
+      const $modal = modalRef.current;
+      $modal.style.top = $modal.offsetTop + (e.pageY - pos.y) + 'px';
+      $modal.style.left = $modal.offsetLeft + (e.pageX - pos.x) + 'px';
+
+      pos.x = e.pageX;
+      pos.y = e.pageY;
+    }, 100);
+  }, []);
+
   useEffect(() => {
     document.addEventListener('click', clickModalOutside);
     document.body.style.overflow = 'hidden';
@@ -26,7 +45,7 @@ const Index = ({
   });
 
   function clickModalOutside(event) {
-    if (!$modal.current.contains(event.target)) {
+    if (!isMouseDown && !modalRef.current.contains(event.target)) {
       hideModal();
     }
   }
@@ -35,16 +54,41 @@ const Index = ({
     <>
       {isBackground && (
         <div
-          className={styles.modal_background}
+          className={`${styles.modal_background} ${
+            isMouseDown ? styles.max_zIndex : ''
+          }`}
           style={{ backgroundColor }}
           onWheel={e => e.stopPropagation()}
+          ref={modalBackgroundRef}
+          onMouseUp={() => {
+            modalBackgroundRef.current.removeEventListener(
+              'mousemove',
+              moveModal,
+            );
+            if (isMouseDown)
+              setTimeout(() => {
+                setMouseDown(false);
+              }, 100);
+          }}
         />
       )}
       <div
         className={styles.modal_container}
-        ref={$modal}
+        ref={modalRef}
+        name="modal"
         style={style}
         onWheel={e => e.stopPropagation()}
+        onMouseDown={e => {
+          if (e.target.getAttribute('name') === 'modal-move-trigger') {
+            modalBackgroundRef.current.addEventListener('mousemove', moveModal);
+            pos.x = e.pageX;
+            pos.y = e.pageY;
+            setMouseDown(true);
+          }
+        }}
+        onMouseUp={() => {
+          if (isMouseDown) setMouseDown(false);
+        }}
       >
         {isCloseButtom && (
           <div className={styles.modal_close_icon}>

--- a/front/src/components/common/Modal/index.jsx
+++ b/front/src/components/common/Modal/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styles from './style.module.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
@@ -6,9 +6,7 @@ import PropTypes from 'prop-types';
 import Tooltip from '../Tooltip';
 import { useEffect } from 'react';
 import { useRef } from 'react';
-import { throttle } from '../../../utils/delay';
-import { useCallback } from 'react';
-import { useMemo } from 'react';
+import useDraggable from '../../../hooks/useDraggable';
 
 const Index = ({
   children,
@@ -21,19 +19,10 @@ const Index = ({
   const modalRef = useRef();
   const modalBackgroundRef = useRef();
 
-  const [isMouseDown, setMouseDown] = useState(false);
-  const pos = useMemo(() => ({ x: 0, y: 0 }), []);
-  const moveModal = useCallback(e => {
-    if (e.pageY === pos.y && e.pageX === pos.x) return;
-    throttle(() => {
-      const $modal = modalRef.current;
-      $modal.style.top = $modal.offsetTop + (e.pageY - pos.y) + 'px';
-      $modal.style.left = $modal.offsetLeft + (e.pageX - pos.x) + 'px';
-
-      pos.x = e.pageX;
-      pos.y = e.pageY;
-    }, 100);
-  }, []);
+  const { isMouseDown, readyMoveElement, stopMoveElement } = useDraggable(
+    modalRef,
+    modalBackgroundRef,
+  );
 
   useEffect(() => {
     document.addEventListener('click', clickModalOutside);
@@ -60,16 +49,7 @@ const Index = ({
           style={{ backgroundColor }}
           onWheel={e => e.stopPropagation()}
           ref={modalBackgroundRef}
-          onMouseUp={() => {
-            modalBackgroundRef.current.removeEventListener(
-              'mousemove',
-              moveModal,
-            );
-            if (isMouseDown)
-              setTimeout(() => {
-                setMouseDown(false);
-              }, 100);
-          }}
+          onMouseUp={stopMoveElement}
         />
       )}
       <div
@@ -79,15 +59,8 @@ const Index = ({
         style={style}
         onWheel={e => e.stopPropagation()}
         onMouseDown={e => {
-          if (e.target.getAttribute('name') === 'modal-move-trigger') {
-            modalBackgroundRef.current.addEventListener('mousemove', moveModal);
-            pos.x = e.pageX;
-            pos.y = e.pageY;
-            setMouseDown(true);
-          }
-        }}
-        onMouseUp={() => {
-          if (isMouseDown) setMouseDown(false);
+          if (e.target.getAttribute('name') !== 'modal-move-trigger') return;
+          readyMoveElement(e);
         }}
       >
         {isCloseButtom && (

--- a/front/src/components/common/Modal/style.module.css
+++ b/front/src/components/common/Modal/style.module.css
@@ -8,10 +8,7 @@
  height: 100vh; 
  z-index: 998; 
  } 
- .max_zIndex {
-    z-index: 1000;
-    cursor:move;
- }
+ .max_zIndex { z-index: 1000; cursor:move; } 
 
 @keyframes openEffect { 
  from { transform: scale(0); } 
@@ -20,4 +17,4 @@
 
 .modal_close_icon { position: absolute; top: 8px; right: 10px; border-radius: 100%; width: 30px; height: 30px; display: flex; justify-content: center; align-items: center; z-index:3; } 
 .modal_close_icon svg { width: 18px; height: 18px; color: #525252; } 
-.modal_close_icon:hover { background: #f1f1f1 ; } 
+.modal_close_icon:hover { background: #f1f1f1; } 

--- a/front/src/components/common/Modal/style.module.css
+++ b/front/src/components/common/Modal/style.module.css
@@ -8,6 +8,10 @@
  height: 100vh; 
  z-index: 998; 
  } 
+ .max_zIndex {
+    z-index: 1000;
+    cursor:move;
+ }
 
 @keyframes openEffect { 
  from { transform: scale(0); } 
@@ -16,4 +20,4 @@
 
 .modal_close_icon { position: absolute; top: 8px; right: 10px; border-radius: 100%; width: 30px; height: 30px; display: flex; justify-content: center; align-items: center; z-index:3; } 
 .modal_close_icon svg { width: 18px; height: 18px; color: #525252; } 
-.modal_close_icon:hover { background: #f1f1f1; } 
+.modal_close_icon:hover { background: #f1f1f1 ; } 

--- a/front/src/components/common/TextField/index.jsx
+++ b/front/src/components/common/TextField/index.jsx
@@ -19,7 +19,7 @@ const Index = React.forwardRef(
     useImperativeHandle(ref, () => ({
       setErrorMessage,
       focus: () => inputRef.current.focus(),
-      value: inputRef.current.value,
+      value: inputValue,
     }));
 
     return (

--- a/front/src/components/common/Tooltip/index.jsx
+++ b/front/src/components/common/Tooltip/index.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styles from './style.module.css';
 import PropTypes from 'prop-types';
 
-const Index = ({ title, children, top = 10 }) => {
+const Index = ({ title, children, top = 10, className = '' }) => {
   return (
-    <div className={styles.tooltip}>
+    <div className={`${styles.tooltip} ${className}`}>
       {children}
       <em style={{ top: `calc(100% + ${top}px)` }}>{title}</em>
     </div>
@@ -15,6 +15,7 @@ Index.propTypes = {
   title: PropTypes.string,
   top: PropTypes.number,
   children: PropTypes.node,
+  className: PropTypes.string,
 };
 
 export default Index;

--- a/front/src/hooks/useDraggable.js
+++ b/front/src/hooks/useDraggable.js
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+import { throttle } from '../utils/delay';
+
+let position = { x: 0, y: 0, top: 0, left: 0 };
+
+export default function useDraggable(moveElementRef, mouseMoveSpaceRef) {
+  const [isMouseDown, setMouseDown] = useState(false);
+
+  const moveElement = useCallback(
+    e => {
+      if (e.pageY === position.y && e.pageX === position.x) return;
+      throttle(() => {
+        position = {
+          top: position.top + (e.pageY - position.y),
+          left: position.left + (e.pageX - position.x),
+          x: e.pageX,
+          y: e.pageY,
+        };
+
+        const $Element = moveElementRef.current;
+        $Element.style.top = position.top + 'px';
+        $Element.style.left = position.left + 'px';
+      }, 100);
+    },
+    [moveElementRef],
+  );
+
+  function readyMoveElement(e) {
+    mouseMoveSpaceRef.current.addEventListener('mousemove', moveElement);
+    position = {
+      x: e.pageX,
+      y: e.pageY,
+      top: moveElementRef.current.offsetTop,
+      left: moveElementRef.current.offsetLeft,
+    };
+    setMouseDown(true);
+  }
+
+  function stopMoveElement() {
+    mouseMoveSpaceRef.current.removeEventListener('mousemove', moveElement);
+    setTimeout(() => {
+      setMouseDown(false);
+    }, 100);
+  }
+
+  return { readyMoveElement, stopMoveElement, isMouseDown };
+}

--- a/front/src/modal/component/CreateEventModal/DateTitleContainer/style.module.css
+++ b/front/src/modal/component/CreateEventModal/DateTitleContainer/style.module.css
@@ -1,4 +1,4 @@
-.date_title { position: relative; left: -10px;  padding: 5px 10px; cursor: pointer; border-radius: 4px; } 
+.date_title { position: relative; left: -10px;  padding: 5px 7px 5px 10px; cursor: pointer; border-radius: 4px; } 
 .date_title_active:hover { background: #f7f7f7; } 
 .date_title > h3 { display: inline-block; border-bottom: 1px solid transparent; } 
 .date_title > h3:hover { border-bottom: 1px solid #afafb0; } 

--- a/front/src/modal/component/CreateEventModal/InviteMemberList/index.jsx
+++ b/front/src/modal/component/CreateEventModal/InviteMemberList/index.jsx
@@ -6,26 +6,24 @@ import { faQuestionCircle, faXmark } from '@fortawesome/free-solid-svg-icons';
 import Tooltip from '../../../../components/common/Tooltip';
 import { useDispatch } from 'react-redux';
 import { removeInviteMember } from '../../../../store/newEvent';
-import { useRef } from 'react';
-import { useEffect } from 'react';
+
 const Index = ({ members }) => {
   const dispatch = useDispatch();
   function clickRemove(member) {
     dispatch(removeInviteMember(member));
   }
 
+  const [helfModalPosition, setHelfModalStyle] = useState({});
+
+  function moveHelfModal(e) {
+    const { top, left } = e.currentTarget.getBoundingClientRect();
+    if (helfModalPosition.top !== top)
+      setHelfModalStyle({ top, left: left + 20, visibility: 'visible' });
+  }
+
   const isExistCanNotInviteMember = Object.values(members).find(
     member => !member.canInvite,
   );
-
-  const helpRef = useRef();
-  const [helfModalPosition, setHelfModalPosition] = useState({});
-  useEffect(() => {
-    if (helpRef.current) {
-      const { top, left } = helpRef.current.getBoundingClientRect();
-      setHelfModalPosition({ top, left: left + 158 });
-    }
-  }, [members]);
 
   return (
     <div>
@@ -61,10 +59,14 @@ const Index = ({ members }) => {
         ))}
         {isExistCanNotInviteMember && (
           <div className={styles.help_container}>
-            <em ref={helpRef}>* 캘린더를 표시할 수 없습니다.</em>
+            <em>* 캘린더를 표시할 수 없습니다.</em>
             <FontAwesomeIcon
               icon={faQuestionCircle}
               className={styles.icon_help}
+              onMouseOver={moveHelfModal}
+              onMouseLeave={() => {
+                setHelfModalStyle({ visibility: 'hidden' });
+              }}
             />
             <div className={styles.help_modal} style={helfModalPosition}>
               <p>

--- a/front/src/modal/component/CreateEventModal/InviteMemberList/style.module.css
+++ b/front/src/modal/component/CreateEventModal/InviteMemberList/style.module.css
@@ -1,11 +1,11 @@
 .invite_members img { width: 28px; height: 28px; border-radius: 100%; margin-right: 10px; box-shadow: 0px 0px 2.5px 0.5px rgba(0, 0, 0, 0.7); border: 2px solid #fff; image-rendering: auto; } 
-.invite_members { width: 80%; } 
+.invite_members { width: 370px;  position: relative; left: -10px; } 
 
 .invite_member_container { width: 100%; display: flex; align-items: center; justify-content: space-between; padding: 5px 5px; border-radius: 5px; } 
 .invite_member_container:hover { background: #f4f4f4; } 
 .invite_member_container:hover .icon_delete { visibility: visible; } 
 
-.invite_member { display: flex; align-items: center; } 
+.invite_member { display: flex; align-items: center; padding-left: 5px; } 
 
 .icon_delete { visibility: hidden; position: static !important; width: 18px !important; height: 18px !important; cursor: pointer; border-radius: 100%; padding: 5px } 
 .icon_delete:hover { background: #e1e1e1; } 
@@ -13,14 +13,10 @@
 .member_info em { font-size: 12px; color: #ababab; } 
 
 .help_container { position: relative; margin-bottom: 5px; } 
-.help_container em { color: #ababab; font-size: 12px; margin-left: 5px;} 
+.help_container em { color: #ababab; font-size: 12px; margin-left: 10px;  } 
 
-.help_modal { position: fixed; z-index: 3; left: 163px; top: 0; display: block !important; border-radius: 5px; } 
-.help_modal { width: 0px !important; height: 0px; background: transparent; padding: 8px !important; overflow: hidden; box-shadow: none; color: transparent;} 
-.help_modal:hover { background: #fff; width: 300px !important; height: 180px; box-shadow: 1px 2px 25px 5px rgba(0, 0, 0, 0.3); padding: 15px !important; color: #343434;}
-
+.help_modal {visibility: hidden; position: fixed; z-index: 3; left: 163px; top: 0; border-radius: 5px; background: #fff; width: 300px !important; height: 180px; box-shadow: 1px 2px 25px 5px rgba(0, 0, 0, 0.3); padding: 15px !important; color: #343434;} 
 .help_modal ul { margin-top: 15px; margin-left: 35px; word-break: break-all; } 
 .help_modal li { list-style-type: disc; } 
 
 .icon_help { width: 14px !important; height: 14px !important; cursor: pointer; margin-left: 10px; padding-top:5px;  color: #ababab !important; } 
-.icon_help:hover .help_modal { visibility: visible !important; } 

--- a/front/src/modal/component/CreateEventModal/index.jsx
+++ b/front/src/modal/component/CreateEventModal/index.jsx
@@ -179,6 +179,7 @@ const Index = ({ children: ModalList }) => {
   );
 
   const [EventInfoListModal, ...RestModal] = ModalList;
+
   return (
     <Modal
       hideModal={initCreateEventModal}
@@ -197,7 +198,7 @@ const Index = ({ children: ModalList }) => {
         })}
       {RestModal}
 
-      <div className={styles.modal_header}>
+      <div className={styles.modal_header} name="modal-move-trigger">
         <FontAwesomeIcon icon={faGripLines} />
       </div>
       <div

--- a/front/src/modal/component/CreateEventModal/style.module.css
+++ b/front/src/modal/component/CreateEventModal/style.module.css
@@ -2,7 +2,7 @@
 .modal_header svg { position: relative; padding: 8px; z-index: 1; width: 18px; height: 18px; color: #afafb0; margin-left: 12px; border-radius: 100%; margin-top: 5px; } 
 .modal_header svg:hover { background: #f1f3f4; } 
 
-.modal_context { margin-top: 33px; width: 460px; height: 100%; color: #6b6b6b; overflow-y: scroll; max-height: 50vh;  overflow-x: hidden; } 
+.modal_context { margin-top: 33px; width: 460px; height: 100%; color: #6b6b6b; overflow-y: overlay; max-height: 50vh;  overflow-x: hidden; } 
 .scroll_hidden { overflow-y: hidden; }
 
 .modal_context button { color: #6b6b6b; border-radius: 5px; cursor: pointer; } 

--- a/front/src/modal/component/CustomAlertModal/index.jsx
+++ b/front/src/modal/component/CustomAlertModal/index.jsx
@@ -17,6 +17,7 @@ const Index = ({ hideModal, modalData }) => {
 
   const dispatch = useDispatch();
   function handleAddAlert(e) {
+    if (!alertRef.current.checkAlertTime()) return;
     dispatch(
       updateNewEventAlert({
         type: allDay ? 'allDay' : 'notAllDay',
@@ -27,6 +28,7 @@ const Index = ({ hideModal, modalData }) => {
     hideModal();
     e.stopPropagation();
   }
+
   return (
     <Modal
       hideModal={hideModal}
@@ -46,7 +48,14 @@ const Index = ({ hideModal, modalData }) => {
           <CustomAlertOfNotAllDay ref={alertRef} />
         )}
         <div className={styles.modal_footer}>
-          <button>취소</button>
+          <button
+            onClick={e => {
+              hideModal();
+              e.stopPropagation();
+            }}
+          >
+            취소
+          </button>
           <button onClick={handleAddAlert}>완료</button>
         </div>
       </div>

--- a/front/src/pages/Main/index.jsx
+++ b/front/src/pages/Main/index.jsx
@@ -19,7 +19,7 @@ const Index = () => {
     if (socket && userInfo) {
       socket.emit('login', { id: userInfo.id });
     }
-  }, []);
+  }, [socket, userInfo]);
 
   useEffect(() => {
     if (socket) {
@@ -27,6 +27,9 @@ const Index = () => {
         alert(data.alert);
       });
     }
+    return () => {
+      socket?.off('alertTest');
+    };
   }, []);
 
   let [isSideBarOn, toggleSideBar] = useState(true);

--- a/front/src/store/newEvent.js
+++ b/front/src/store/newEvent.js
@@ -69,11 +69,13 @@ const newEvent = createSlice({
 
     updateNewEventTime(state, { payload }) {
       const { type, minute, hour } = payload;
-      const date = new Date(state[type]);
-      if (minute >= 0) date.setMinutes(minute);
-      if (hour >= 0) date.setHours(hour);
-
-      state[type] = date.getTime();
+      let date = new Moment(state[type]);
+      if (minute >= 0) date = date.setMinute(minute);
+      if (hour >= 0) date = date.setHour(hour);
+      if (type === 'endTime' && state.startTime > date.time) {
+        date = date.addDate(1);
+      }
+      state[type] = date.time;
     },
 
     updateNewEventAlert(state, { payload }) {

--- a/front/src/utils/delay.js
+++ b/front/src/utils/delay.js
@@ -1,15 +1,19 @@
-let timer = null;
+export const throttle = (function () {
+  let timer = null;
+  return (callback, time) => {
+    if (!timer) {
+      timer = setTimeout(() => {
+        timer = null;
+        callback();
+      }, time);
+    }
+  };
+})();
 
-export function throttle(callback, time) {
-  if (!timer) {
-    timer = setTimeout(() => {
-      timer = null;
-      callback();
-    }, time);
-  }
-}
-
-export function debounce(callback, time) {
-  if (timer) clearTimeout(timer);
-  timer = setTimeout(() => callback(), time);
-}
+export const debounce = (function () {
+  let timer = null;
+  return (callback, time) => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => callback(), time);
+  };
+})();


### PR DESCRIPTION
## ⭐ Point <!-- 구현한 기능 혹은 목표에 대한 간략한 설명 -->
- 이벤트 생성 입력 데이터(이벤트 시간 및 알림) 제한 구현
- 마우스 드래그로 이벤트 생성 모달 이동 기능 구현

## 👨‍💻 작업 내용 <!-- 추가 설명이 필요한 경우 기입 -->
### 1. 이벤트 생성 입력 데이터 제한 구현 (#249)
#### 알림 설정 제한
- 시간 단위 별로 범위를 벗어날 경우 입력 및 설정 제한

#### 이벤트 시간 제한
- 종료 시간이 시작 시간보다 작은 경우, 강제로 시작 시간보다 크게 변경

<br/>

### 2. 마우스 드래그로 이벤트 생성 모달 이동 기능 구현 (#257)
#### 이벤트 생성 모달의 헤더를 마우스 드래그하여 모달을 원하는 위치로 이동 
- 이동 전 모달의 `offsetTop`과 `offsetLeft`를 기준으로 이동 전의 마우스 위치(`pageX`, `pageY`)와 이동 후의 마우스 위치(`pageX`, `pageY`)의 차이값을 각각 더해줌
- `useDraggable` Hook으로 관련 로직 추출

#### [ 해결한 버그 💥 ]
#### 모달의 위치가 정확하게 마우스 포인터의 위치로 이동하지 않음
- 이벤트가 발생했을 때의 요소의 top과 left의 값 계산에서 생긴 문제 
- `mousemove` 이벤트가 발생했을 때 요소의 위치를 가져올 경우, 이전에 계산한 요소의 위치 값이 아닌 이동 중인 요소의 위치 값을 가져오는 경우가 있음

#### 해결방안  
- 이동 전의 마우스 위치와 마찬가지로, 요소의 이전 위치(top,left)를 별도의 변수로 저장하여 사용

<br/>

#### ⚡ Related Issues <!-- 관련된 이슈 번호 기입 -->
Closes #249
Closes #257