### PR TITLE
fix: 이벤트 상세보기 API의 응답 데이터 수정 (#261)

### DIFF
--- a/front/src/components/calendar/EventBar/index.jsx
+++ b/front/src/components/calendar/EventBar/index.jsx
@@ -29,22 +29,11 @@ const Index = ({
     const { offsetTop = 0, offsetLeft = 0 } = handleEventDetailMadal(e);
     const { top, left } = e.currentTarget.getBoundingClientRect();
 
-    const { data } = await getEventDetail(event);
-    const { EventMembers, EventHost, realTimeAlert } = data;
-    const alerts =
-      realTimeAlert?.map(alert => {
-        const types = { week: '주', day: '일', hour: '시간', minute: '분' };
-        return { ...alert, type: types[alert.type] };
-      }) || [];
+    const eventData = await getEventDetail(event);
     setEventDetailModalData(data => ({
       ...data,
-      event: { ...event, EventMembers, EventHost, alerts },
-      style: {
-        position: {
-          top: top + offsetTop,
-          left: left + offsetLeft,
-        },
-      },
+      event: eventData,
+      style: { top: top + offsetTop, left: left + offsetLeft },
     }));
   }
 

--- a/front/src/components/calendar/EventBar/style.module.css
+++ b/front/src/components/calendar/EventBar/style.module.css
@@ -1,1 +1,1 @@
-.empty_event_bar { height: 1.35rem; max-height: 28px; margin-bottom: 4px; position: relative; width: 1px; } 
+.empty_event_bar { height: 1.35rem; max-height: 28px; margin-bottom: 5px; position: relative; width: 1px; } 

--- a/front/src/components/searchDetall/index.jsx
+++ b/front/src/components/searchDetall/index.jsx
@@ -3,12 +3,12 @@ import { useSelector } from 'react-redux';
 import styles from './style.module.css';
 import EventDetailModal from '../../modal/component/EventDetailModal';
 import useEventModal from '../../hooks/useEventModal';
-import axios from '../../utils/token';
-import { EVENT_URL } from '../../constants/api';
 import { EVENT } from '../../store/events';
+import { getEventDetail } from '../../store/thunk/event';
 
 const Index = () => {
-  let { isModalShown, showModal, hideModal, modalData } = useEventModal();
+  let { isModalShown, showModal, hideModal, modalData, setModalData } =
+    useEventModal();
 
   //redux 검색 정보 상태관리
   let searchValue = useSelector(state => {
@@ -26,22 +26,15 @@ const Index = () => {
 
   //이벤트 팝업창 컨트롤
   async function clickEventBar(e, event) {
-    const { top, right } = e.currentTarget.getBoundingClientRect();
-    const { data } = await axios.post(EVENT_URL.GET_EVENT_DETAIL, {
-      eventId: event.PrivateCalendarId ? event.groupEventId : event.id,
-    });
-    const { EventMembers, EventHost } = data;
-    showModal(data => ({
-      ...data,
-      event: { ...event, EventMembers, EventHost },
-      style: {
-        position: {
-          top: top,
-          left: right,
-        },
-      },
-    }));
     e.stopPropagation();
+
+    const { top, right } = e.currentTarget.getBoundingClientRect();
+    const eventData = await getEventDetail(event);
+    if (!isModalShown) showModal();
+    setModalData({
+      event: eventData,
+      style: { top: top, left: right },
+    });
   }
 
   return (

--- a/front/src/modal/component/EventDetailModal/EventMemberList/style.module.css
+++ b/front/src/modal/component/EventDetailModal/EventMemberList/style.module.css
@@ -1,4 +1,6 @@
 .user_info { display: flex; margin-bottom: 10px; } 
+.user_info:last-child { margin-bottom: 0px; } 
+
 .user_info .user_profile { position: relative; margin-right: 15px; } 
 .user_info .user_profile img { position: relative; border-radius: 100%; background: white; width: 25px; height: 25px; color: white;  } 
 .user_info .user_state { border-radius: 100%; background: gainsboro; color: #515151; padding: 2px; width: 10px; height: 10px; border: 1px solid white; position: absolute; left:18px; top: 11px; } 

--- a/front/src/modal/component/EventDetailModal/index.jsx
+++ b/front/src/modal/component/EventDetailModal/index.jsx
@@ -44,7 +44,7 @@ const Index = ({ modalData, hideModal }) => {
     calendarByEventIdSelector(state, groupEvent),
   );
   useEffect(() => {
-    let { top = 0, left = 0 } = style?.position || {};
+    let { top = 0, left = 0 } = style || {};
     if (top + $modal.current?.offsetHeight + 15 > window.innerHeight) {
       top = window.innerHeight - $modal.current?.offsetHeight - 35;
     }


### PR DESCRIPTION
## ⭐ Point <!-- 구현한 기능 혹은 목표에 대한 간략한 설명 -->
이벤트 상세보기 API의 응답 데이터 수정

## 👨‍💻 작업 내용 <!-- 추가 설명이 필요한 경우 기입 -->
- 캘린더 종류(개인/그룹)에 따라 이벤트 상세보기 API 요청 
- 이벤트 상세보기 API의 응답 데이터 수정
- 개인 캘린더의 이벤트 경우 `id` 및 `PrivateCalendarId`를 음수로 변환하여 사용

<br/>

#### ⚡ Related Issues <!-- 관련된 이슈 번호 기입 -->
Closes #261
