### PR TITLE
fix: 시간 단위 캘린더의 종일 이벤트 분류 및 표시

### DIFF
--- a/front/src/components/calendar/EventBar/index.jsx
+++ b/front/src/components/calendar/EventBar/index.jsx
@@ -43,7 +43,7 @@ const Index = ({
   const eventBarColor = event?.color || eventBar?.eventColor || calendarColor;
   const isSelected = eventDetailModalData.event?.id === event?.id;
 
-  if (!eventBar || !eventBar.scale) {
+  if (!eventBar?.scale) {
     return <div className={styles.empty_event_bar} />;
   }
 

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/EventList/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/EventList/index.jsx
@@ -3,18 +3,13 @@ import styles from './style.module.css';
 import PropTypes from 'prop-types';
 
 import ReadMoreTitle from './ReadMoreTitle';
-import Moment from '../../../../../../utils/moment';
-
-import { useSelector } from 'react-redux';
-import { eventsByEventIdsSelector } from '../../../../../../store/selectors/events';
-
-import { EVENT } from '../../../../../../store/events';
 import AllDayEvent from './AllDayEvent';
 import EventBar from '../../../../EventBar';
 import { useEffect } from 'react';
 
 const Index = ({
   date,
+  events,
   eventBars,
   newEventEmptyBar,
   readMore,
@@ -22,28 +17,25 @@ const Index = ({
 }) => {
   const $eventList = useRef();
 
-  const events = useSelector(state =>
-    eventsByEventIdsSelector(state, eventBars || []),
-  ).filter(isAllDay);
-
   useEffect(() => {
-    if (!readMore && events.length > 3) {
+    if (!readMore && eventBars.length > 3) {
       setReadMore(false);
     }
-  }, [events]);
+  }, [eventBars]);
 
   function clickReadMore() {
     setReadMore(true);
   }
 
-  function isAllDay(event) {
-    return (
-      event.allDay === EVENT.allDay.true ||
-      new Moment(event.startTime)
-        .resetTime()
-        .calculateDateDiff(new Moment(event.endTime).resetTime().time) !== 0
-    );
-  }
+  const previewEventBars = readMore
+    ? eventBars
+    : eventBars.length > 3
+    ? eventBars.slice(0, 3)
+    : eventBars;
+
+  const resetEventBars = eventBars
+    .slice(previewEventBars.length)
+    .filter(eventBar => eventBar);
 
   return (
     <div
@@ -52,20 +44,15 @@ const Index = ({
       data-drag-date={date.time}
     >
       {newEventEmptyBar && <EventBar />}
-      {(readMore
-        ? events
-        : events.length > 3
-        ? events.slice(0, 2)
-        : events.slice(0, 3)
-      ).map((event, index) => (
+      {previewEventBars.map((eventBar, index) => (
         <AllDayEvent
           key={index}
-          event={event}
-          eventBar={eventBars.find(eventBar => eventBar.id === event.id)}
+          eventBar={eventBar}
+          event={events[eventBar?.id]}
         />
       ))}
-      {events.length > 3 && readMore === false && (
-        <ReadMoreTitle events={events.slice(2)} clickReadMore={clickReadMore} />
+      {eventBars.length > 3 && readMore === false && (
+        <ReadMoreTitle events={resetEventBars} clickReadMore={clickReadMore} />
       )}
     </div>
   );
@@ -73,6 +60,7 @@ const Index = ({
 
 Index.propTypes = {
   date: PropTypes.object,
+  events: PropTypes.object,
   eventBars: PropTypes.array,
   newEventEmptyBar: PropTypes.bool,
   readMore: PropTypes.bool,

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styles from './style.module.css';
 
@@ -10,9 +10,8 @@ import {
   newEventBarByTimeSelector,
   newEventEmptyBarByTimeSelector,
 } from '../../../../../store/selectors/newEvent';
-import { eventsByDateSelector } from '../../../../../store/selectors/events';
 
-const Index = ({ date, readMore, setReadMore }) => {
+const Index = ({ dateId, date, events, eventBars, readMore, setReadMore }) => {
   const newEventBar = useSelector(state =>
     newEventBarByTimeSelector(state, date.time),
   );
@@ -21,7 +20,9 @@ const Index = ({ date, readMore, setReadMore }) => {
     newEventEmptyBarByTimeSelector(state, date.time),
   );
 
-  const eventBars = useSelector(state => eventsByDateSelector(state, date));
+  useEffect(() => {
+    if (dateId === 0) setReadMore(null);
+  }, [setReadMore, dateId]);
 
   return (
     <div
@@ -32,6 +33,7 @@ const Index = ({ date, readMore, setReadMore }) => {
       {newEventBar && <NewEvent eventBar={newEventBar} />}
       <EventList
         date={date}
+        events={events}
         eventBars={eventBars}
         newEventEmptyBar={newEventEmptyBar}
         readMore={readMore}
@@ -43,7 +45,10 @@ const Index = ({ date, readMore, setReadMore }) => {
 };
 
 Index.propTypes = {
+  dateId: PropTypes.number,
   date: PropTypes.object,
+  events: PropTypes.object,
+  eventBars: PropTypes.array,
   readMore: PropTypes.bool,
   setReadMore: PropTypes.func,
 };

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/index.jsx
@@ -14,8 +14,9 @@ import { EventBarContext } from '../../../../context/EventBarContext';
 import Tooltip from '../../../common/Tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
+import { classifyEventsByDate } from '../../../../store/events';
 
-const Index = ({ dates }) => {
+const Index = ({ dates, events }) => {
   const dispatch = useDispatch();
   const {
     handleMouseDown,
@@ -85,7 +86,13 @@ const Index = ({ dates }) => {
     handleMouseDown(e);
   }
 
+  const eventBars = classifyEventsByDate(events);
+  const eventsById = events.reduce((obj, event) => {
+    obj[event.id] = event;
+    return obj;
+  }, {});
   const [readMore, setReadMore] = useState(null);
+
   return (
     <EventBarContext.Provider value={dragContextData}>
       <div
@@ -115,9 +122,16 @@ const Index = ({ dates }) => {
         </div>
         <div className={styles.calendar_dates}>
           <div className={styles.calendar_axis_line} />
-          {dates.map(date => (
+          {dates.map((date, index) => (
             <div key={date.time}>
-              <Date date={date} readMore={readMore} setReadMore={setReadMore} />
+              <Date
+                dateId={index}
+                date={date}
+                events={eventsById}
+                eventBars={eventBars[date.time] || []}
+                readMore={readMore}
+                setReadMore={setReadMore}
+              />
             </div>
           ))}
         </div>
@@ -128,6 +142,7 @@ const Index = ({ dates }) => {
 
 Index.propTypes = {
   dates: PropTypes.array,
+  events: PropTypes.array,
 };
 
 export default Index;

--- a/front/src/store/events.js
+++ b/front/src/store/events.js
@@ -84,7 +84,7 @@ const events = createSlice({
 export const { resetEventState, updateEventBar } = events.actions;
 export default events.reducer;
 
-function classifyEventsByDate(events) {
+export function classifyEventsByDate(events) {
   return events.reduce((byDate, event) => {
     if (!isCheckedCalander(event)) return byDate;
 


### PR DESCRIPTION
## ⭐ Point <!-- 구현한 기능 혹은 목표에 대한 간략한 설명 -->
시간 단위 캘린더의 종일 이벤트 분류 및 표시

## 👨‍💻 작업 내용 <!-- 추가 설명이 필요한 경우 기입 -->
- 종일 이벤트 목록에 종일 이벤트만 표시
- 이벤트바 겹침 현상 해결

<br/>

#### ⚡ Related Issues <!-- 관련된 이슈 번호 기입 -->
Closes #IssueNumber
