### PR TITLE
feat: 일/4일 단위 캘린더의 종일 이벤트 목록 표시 (#318)

### DIFF
--- a/front/src/components/calendar/EventBar/EventFillBar/index.jsx
+++ b/front/src/components/calendar/EventBar/EventFillBar/index.jsx
@@ -23,7 +23,13 @@ const Index = ({
       onClick={clickEventBar}
       onContextMenu={e => onContextMenu(e, event)}
     >
-      {left && <div className={styles.event_left} style={eventBarStyle.left} />}
+      {left && (
+        <div
+          className={styles.event_left}
+          style={eventBarStyle.left}
+          name="event-left"
+        />
+      )}
 
       <div className={styles.event_bar}>
         <div
@@ -47,17 +53,23 @@ const Index = ({
 
       {right && (
         <>
-          <div className={styles.event_right} style={eventBarStyle.right} />
+          <div
+            className={styles.event_right}
+            style={eventBarStyle.right}
+            name="event-right"
+          />
           {(event?.state === EVENT.state.default ||
             event?.state === EVENT.state.refuse) && (
             <>
               <div
                 className={`${styles.event_right} ${styles.event_right_extra}`}
                 style={eventBarStyle.right}
+                name="event-right"
               />
               <div
                 className={`${styles.event_right} ${styles.event_right_line}`}
                 style={eventBarStyle.right}
+                name="event-right-line"
               />
             </>
           )}

--- a/front/src/components/calendar/EventBar/EventFillBar/style.module.css
+++ b/front/src/components/calendar/EventBar/EventFillBar/style.module.css
@@ -5,7 +5,7 @@
 .event_container:hover .event_left { filter: brightness(0.9); } 
 .event_container:hover .event_right { filter: brightness(0.9); } 
 
-.event_bar { width: 100%; height: 100%; } 
+.event_bar { width: 100%; height: 100%;  min-width: 0; flex: 1;  } 
 .event_bar_calendar { position: absolute; flex-shrink: 0; z-index: 4; width: 4px !important; height: 100%; border-top-left-radius: 3px; border-bottom-left-radius: 3px; } 
 .event_bar_main { position: relative; width: 100%; height: 100%; display: flex; border-radius: 3px; align-items: center; cursor: pointer; z-index: 3; word-break: break-all; } 
 .event_bar_main > p { width: 90%; font-size: 0.75rem; padding-left: 8px; vertical-align: middle; text-align: left; white-space: nowrap; overflow:hidden; text-overflow: ellipsis; } 
@@ -14,8 +14,8 @@
 .none_left_border { border-top-left-radius : 0px; border-bottom-left-radius : 0px; } 
 .none_right_border { border-top-right-radius : 0px; border-bottom-right-radius : 0px; } 
 
-.event_left { position: relative; border: 11px solid transparent; border-left: 0px; border-right: 9px solid red; left: 0px; z-index: 5; } 
-.event_right { position: absolute; right: -11px !important; top: 0px; border: 11px solid transparent; border-right: 0px; border-left: 9px solid red; right: -5px; z-index: 5; } 
+.event_left { position: relative; border: 0.74rem solid transparent; border-left: 0px; border-right: 9px solid red; left: 0px; z-index: 5; } 
+.event_right { position: absolute; right: -11px !important; top: 0px; border: 0.74rem solid transparent; border-right: 0px; border-left: 9px solid red; right: -5px; z-index: 5; } 
 .event_right_line { border-left-color: white !important; right: -10.5px !important; } 
 .event_right_extra { right: -11px !important; } 
 

--- a/front/src/components/calendar/MonthCalendar/CalendarBody/Date/EventList/index.jsx
+++ b/front/src/components/calendar/MonthCalendar/CalendarBody/Date/EventList/index.jsx
@@ -16,8 +16,9 @@ import {
 } from '../../../../../../context/EventModalContext';
 import { calendarByEventIdsSelector } from '../../../../../../store/selectors/calendars';
 import { newEventEmptyBarByTimeSelector } from '../../../../../../store/selectors/newEvent';
+import Moment from '../../../../../../utils/moment';
 
-const Index = ({ date, maxHeight }) => {
+const Index = ({ date, maxHeight, month }) => {
   const { showModal: showEventListModal, hideModal: hideEventListModal } =
     useContext(EventListModalContext);
   const { showModal: showEventDetailModal, hideModal: hideEventDetailModal } =
@@ -72,6 +73,7 @@ const Index = ({ date, maxHeight }) => {
     hideEventDetailModal();
     e.preventDefault();
   }
+
   return (
     <div
       className={styles.event_list}
@@ -91,6 +93,16 @@ const Index = ({ date, maxHeight }) => {
               ? handleSimpleEventOptionModal
               : null
           }
+          left={
+            events[index] &&
+            new Moment(events[index].startTime).resetTime().time <
+              month[0][0].time
+          }
+          right={
+            events[index] &&
+            new Moment(events[index].endTime).resetTime().time >
+              month[month.length - 1][6].time
+          }
         />
       ))}
       {restEvent.length > 0 && (
@@ -103,6 +115,7 @@ const Index = ({ date, maxHeight }) => {
 Index.propTypes = {
   date: PropTypes.object,
   maxHeight: PropTypes.number,
+  month: PropTypes.array,
 };
 
 export default Index;

--- a/front/src/components/calendar/MonthCalendar/CalendarBody/Date/EventList/style.module.css
+++ b/front/src/components/calendar/MonthCalendar/CalendarBody/Date/EventList/style.module.css
@@ -4,3 +4,14 @@
     position: absolute;
     text-align: left;
 }
+
+.event_list [name="event-right"] {
+    position: relative !important;
+    right: -2px !important;
+}
+
+.event_list [name="event-right-line"] {
+    position: relative !important;
+    right: -1.5px !important;
+}
+

--- a/front/src/components/calendar/MonthCalendar/CalendarBody/Date/index.jsx
+++ b/front/src/components/calendar/MonthCalendar/CalendarBody/Date/index.jsx
@@ -11,7 +11,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { newEventBarByTimeSelector } from '../../../../../store/selectors/newEvent';
 
-const Index = ({ date }) => {
+const Index = ({ date, month }) => {
   const { moveDayCalendar } = useNavigateDayCalendar();
   const containerDiv = useRef();
   const [maxHeight, setMaxHight] = useState(0);
@@ -41,7 +41,7 @@ const Index = ({ date }) => {
         ref={containerDiv}
       >
         {newEventBar && <NewEvent eventBar={newEventBar} />}
-        <EventList date={date} maxHeight={maxHeight} />
+        <EventList date={date} maxHeight={maxHeight} month={month} />
         <div className={styles.event_list}></div>
       </div>
     </td>
@@ -66,6 +66,7 @@ function isSameDate(date, otherDate) {
 
 Index.propTypes = {
   date: PropTypes.object,
+  month: PropTypes.array,
 };
 
 export default Index;

--- a/front/src/components/calendar/MonthCalendar/CalendarBody/Week/index.jsx
+++ b/front/src/components/calendar/MonthCalendar/CalendarBody/Week/index.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Date from '../Date';
 
-const Index = ({ week }) => {
+const Index = ({ week, month }) => {
   return (
     <tr>
       {week.map((date, index) => (
-        <Date key={index} date={date} />
+        <Date key={index} date={date} month={month} />
       ))}
     </tr>
   );
@@ -14,6 +14,7 @@ const Index = ({ week }) => {
 
 Index.propTypes = {
   week: PropTypes.array,
+  month: PropTypes.array,
 };
 
 export default Index;

--- a/front/src/components/calendar/MonthCalendar/CalendarBody/index.jsx
+++ b/front/src/components/calendar/MonthCalendar/CalendarBody/index.jsx
@@ -8,7 +8,7 @@ const Index = ({ month }) => {
   return (
     <>
       {month.map((week, index) => (
-        <Week key={index} week={week} />
+        <Week key={index} week={week} month={month} />
       ))}
     </>
   );

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/EventList/AllDayEvent/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/EventList/AllDayEvent/index.jsx
@@ -8,8 +8,9 @@ import {
 } from '../../../../../../../context/EventModalContext';
 import { calendarByEventIdSelector } from '../../../../../../../store/selectors/calendars';
 import EventBar from '../../../../../EventBar';
+import Moment from '../../../../../../../utils/moment';
 
-const Index = ({ eventBar, event }) => {
+const Index = ({ dates, eventBar, event }) => {
   const { showModal: showEventDetailModal, hideModal: hideEventDetailModal } =
     useContext(EventDetailModalContext);
   const {
@@ -38,6 +39,14 @@ const Index = ({ eventBar, event }) => {
 
   return (
     <EventBar
+      left={
+        event && new Moment(event.startTime).resetTime().time < dates[0].time
+      }
+      right={
+        event &&
+        new Moment(event.endTime).resetTime().time >
+          dates[dates.length - 1].time
+      }
       event={event}
       calendar={calendar}
       eventBar={eventBar}
@@ -50,6 +59,7 @@ const Index = ({ eventBar, event }) => {
 };
 
 Index.propTypes = {
+  dates: PropTypes.array,
   eventBar: PropTypes.object,
   event: PropTypes.object,
 };

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/EventList/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/EventList/index.jsx
@@ -9,6 +9,7 @@ import { useEffect } from 'react';
 
 const Index = ({
   date,
+  dates,
   events,
   eventBars,
   newEventEmptyBar,
@@ -47,6 +48,7 @@ const Index = ({
       {previewEventBars.map((eventBar, index) => (
         <AllDayEvent
           key={index}
+          dates={dates}
           eventBar={eventBar}
           event={events[eventBar?.id]}
         />
@@ -60,6 +62,7 @@ const Index = ({
 
 Index.propTypes = {
   date: PropTypes.object,
+  dates: PropTypes.array,
   events: PropTypes.object,
   eventBars: PropTypes.array,
   newEventEmptyBar: PropTypes.bool,

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/Date/index.jsx
@@ -11,7 +11,15 @@ import {
   newEventEmptyBarByTimeSelector,
 } from '../../../../../store/selectors/newEvent';
 
-const Index = ({ dateId, date, events, eventBars, readMore, setReadMore }) => {
+const Index = ({
+  dateId,
+  date,
+  dates,
+  events,
+  eventBars,
+  readMore,
+  setReadMore,
+}) => {
   const newEventBar = useSelector(state =>
     newEventBarByTimeSelector(state, date.time),
   );
@@ -33,6 +41,7 @@ const Index = ({ dateId, date, events, eventBars, readMore, setReadMore }) => {
       {newEventBar && <NewEvent eventBar={newEventBar} />}
       <EventList
         date={date}
+        dates={dates}
         events={events}
         eventBars={eventBars}
         newEventEmptyBar={newEventEmptyBar}
@@ -47,6 +56,8 @@ const Index = ({ dateId, date, events, eventBars, readMore, setReadMore }) => {
 Index.propTypes = {
   dateId: PropTypes.number,
   date: PropTypes.object,
+  dates: PropTypes.array,
+  unitWeekDay: PropTypes.number,
   events: PropTypes.object,
   eventBars: PropTypes.array,
   readMore: PropTypes.bool,

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/index.jsx
@@ -131,6 +131,7 @@ const Index = ({ dates, events, unitWeekDay }) => {
               <Date
                 dateId={index}
                 date={date}
+                dates={dates}
                 events={eventsById}
                 eventBars={eventBars[date.time] || []}
                 readMore={readMore}

--- a/front/src/components/calendar/TimeCalendar/AllDayEventList/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/AllDayEventList/index.jsx
@@ -16,7 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { classifyEventsByDate } from '../../../../store/events';
 
-const Index = ({ dates, events }) => {
+const Index = ({ dates, events, unitWeekDay }) => {
   const dispatch = useDispatch();
   const {
     handleMouseDown,
@@ -86,7 +86,11 @@ const Index = ({ dates, events }) => {
     handleMouseDown(e);
   }
 
-  const eventBars = classifyEventsByDate(events);
+  const eventBars = classifyEventsByDate(
+    events,
+    unitWeekDay,
+    dates[dates.length - 1],
+  );
   const eventsById = events.reduce((obj, event) => {
     obj[event.id] = event;
     return obj;
@@ -143,6 +147,7 @@ const Index = ({ dates, events }) => {
 Index.propTypes = {
   dates: PropTypes.array,
   events: PropTypes.array,
+  unitWeekDay: PropTypes.number,
 };
 
 export default Index;

--- a/front/src/components/calendar/TimeCalendar/CalendarHeader/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/CalendarHeader/index.jsx
@@ -15,7 +15,7 @@ const Index = ({ dates = [] }) => {
           <p
             className={styles.calendar_header_date}
             onClick={() => {
-              moveDayCalendar(date);
+              moveDayCalendar(date.toObject());
             }}
           >
             {date.date}

--- a/front/src/components/calendar/TimeCalendar/index.jsx
+++ b/front/src/components/calendar/TimeCalendar/index.jsx
@@ -16,7 +16,7 @@ import ModalLayout from '../../../modal/layout/ModalLayout';
 import SimpleEventOptionModal from '../../../modal/component/SimpleEventOptionModal';
 import { SimpleEventOptionModalContext } from '../../../context/EventModalContext';
 
-const Index = ({ dates }) => {
+const Index = ({ dates, unitWeekDay }) => {
   const events = useSelector(allEventSelector);
   const allDayEvents = events.filter(isAllDay);
   const notAllDayEvents = events.filter(event => !isAllDay(event));
@@ -39,7 +39,11 @@ const Index = ({ dates }) => {
         >
           <div className={styles.calendar_container}>
             <CalendarHeader dates={dates} />
-            <AllDayEventList dates={dates} events={allDayEvents} />
+            <AllDayEventList
+              dates={dates}
+              events={allDayEvents}
+              unitWeekDay={unitWeekDay}
+            />
             <div className={styles.calendar_context}>
               <CalendarAxis />
               <CalendarBody dates={dates} events={notAllDayEvents} />
@@ -53,6 +57,7 @@ const Index = ({ dates }) => {
 
 Index.propTypes = {
   dates: PropTypes.array,
+  unitWeekDay: PropTypes.number,
 };
 
 export default Index;

--- a/front/src/hooks/useCreateEventBar.js
+++ b/front/src/hooks/useCreateEventBar.js
@@ -13,7 +13,13 @@ export default function useCreateEventBar(selectedDateRange = initDateRange) {
   return { newEventBars, setNewEventBars };
 }
 
-export function createEventBar(dateRange) {
+export function createEventBar(
+  dateRange,
+  unitWeekDay = 7,
+  firstStandardDate = null,
+) {
+  if (!unitWeekDay) return [];
+
   let [minDateTime, maxDateTime] = Object.values(dateRange).sort(ASC_NUMBER);
   if (!minDateTime || !maxDateTime) return [];
 
@@ -21,19 +27,30 @@ export function createEventBar(dateRange) {
   let start = new Moment(new Date(minDateTime));
   const end = new Moment(new Date(maxDateTime));
 
-  while (start.time <= end.time) {
-    const saturday = start.addDate(6 - start.day);
+  let standardDate = new Moment(start.time);
+  if (firstStandardDate) {
+    while (firstStandardDate.day !== standardDate.day)
+      standardDate = standardDate.addDate(1);
 
-    if (saturday.time >= end.time) {
+    if (start.resetTime().time < standardDate.addDate(-(unitWeekDay - 1)).time)
+      start = standardDate.addDate(-(unitWeekDay - 1));
+  } else standardDate = start.addDate(unitWeekDay - start.day - 1);
+
+  while (start.time <= end.time) {
+    if (standardDate.time >= end.time) {
       eventBars.push({
         time: start.time,
-        scale: end.day - start.day + 1,
+        scale: start.calculateDateDiff(end.time) + 1,
       });
       break;
     }
 
-    eventBars.push({ time: start.time, scale: saturday.day - start.day + 1 });
-    start = saturday.addDate(1);
+    eventBars.push({
+      time: start.time,
+      scale: start.calculateDateDiff(standardDate.time) + 1,
+    });
+    start = standardDate.addDate(1);
+    standardDate = standardDate.addDate(unitWeekDay);
   }
 
   return eventBars;

--- a/front/src/hooks/useCreateEventBar.js
+++ b/front/src/hooks/useCreateEventBar.js
@@ -24,16 +24,17 @@ export function createEventBar(
   if (!minDateTime || !maxDateTime) return [];
 
   const eventBars = [];
-  let start = new Moment(new Date(minDateTime));
-  const end = new Moment(new Date(maxDateTime));
+  let start = new Moment(new Date(minDateTime)).resetTime();
+  const end = new Moment(new Date(maxDateTime)).resetTime();
 
-  let standardDate = new Moment(start.time);
+  let standardDate = null;
   if (firstStandardDate) {
-    while (firstStandardDate.day !== standardDate.day)
-      standardDate = standardDate.addDate(1);
+    standardDate = new Moment(firstStandardDate.time);
+    while (standardDate.addDate(-unitWeekDay).time > start.time)
+      standardDate = standardDate.addDate(-unitWeekDay);
 
-    if (start.resetTime().time < standardDate.addDate(-(unitWeekDay - 1)).time)
-      start = standardDate.addDate(-(unitWeekDay - 1));
+    const firstDate = standardDate.addDate(-(unitWeekDay - 1));
+    if (start.time < firstDate.time) start = firstDate;
   } else standardDate = start.addDate(unitWeekDay - start.day - 1);
 
   while (start.time <= end.time) {

--- a/front/src/modal/component/EventListModal/style.module.css
+++ b/front/src/modal/component/EventListModal/style.module.css
@@ -3,6 +3,7 @@
 .modal_container > h1 { font-size: 20px; margin-top:3px; margin-bottom: 10px; } 
 
 .modal_container > div { height: 20px; } 
+.modal_container [name="event-right"], .modal_container [name="event-right-line"], .modal_container [name="event-left"] { border-top-width: 11px; border-bottom-width: 11px; } 
 
 .event_bar_active { z-index: 20; } 
 .event_bar_active[name="event_bar"], .event_bar_active [name="event_bar"] { 

--- a/front/src/pages/DayCalendarPage/index.jsx
+++ b/front/src/pages/DayCalendarPage/index.jsx
@@ -1,15 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styles from './style.module.css';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TimeCalendar from '../../components/calendar/TimeCalendar';
+import { getAllCalendarAndEvent } from '../../store/thunk/event';
 
 const Index = () => {
   const selectedDate = useSelector(state => state.date.selectedDate);
   const dates = [selectedDate];
 
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(
+      getAllCalendarAndEvent({
+        startTime: selectedDate.time,
+        endTime: selectedDate.time,
+      }),
+    );
+  }, [dispatch, dates]);
+
   return (
     <div className={styles.day_calendar}>
-      <TimeCalendar dates={dates} />
+      <TimeCalendar dates={dates} unitWeekDay={1} />
     </div>
   );
 };

--- a/front/src/pages/FourDaysCalendarPage/index.jsx
+++ b/front/src/pages/FourDaysCalendarPage/index.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TimeCalendar from '../../components/calendar/TimeCalendar';
+import { getAllCalendarAndEvent } from '../../store/thunk/event';
 import Moment from '../../utils/moment';
 
 const Index = () => {
@@ -9,7 +10,17 @@ const Index = () => {
   const date = new Moment(selectedDate);
   const dates = Array.from(Array(4), (_, i) => date.addDate(i));
 
-  return <TimeCalendar dates={dates} />;
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(
+      getAllCalendarAndEvent({
+        startTime: dates[0].time,
+        endTime: dates[3].time,
+      }),
+    );
+  }, [dispatch, dates]);
+
+  return <TimeCalendar dates={dates} unitWeekDay={4} />;
 };
 
 export default Index;

--- a/front/src/pages/WeekCalendarPage/index.jsx
+++ b/front/src/pages/WeekCalendarPage/index.jsx
@@ -20,7 +20,7 @@ const Index = () => {
     );
   }, [dispatch, dates]);
 
-  return <TimeCalendar dates={dates} />;
+  return <TimeCalendar dates={dates} unitWeekDay={7} />;
 };
 
 export default Index;

--- a/front/src/store/events.js
+++ b/front/src/store/events.js
@@ -84,16 +84,24 @@ const events = createSlice({
 export const { resetEventState, updateEventBar } = events.actions;
 export default events.reducer;
 
-export function classifyEventsByDate(events) {
+export function classifyEventsByDate(
+  events,
+  unitWeekDay = 7,
+  firstStandardDate = null,
+) {
   return events.reduce((byDate, event) => {
     if (!isCheckedCalander(event)) return byDate;
 
     const endDate = new Moment(new Date(event.endTime)).resetTime();
     const startDate = new Moment(new Date(event.startTime)).resetTime();
-    const eventBars = createEventBar({
-      standardDateTime: startDate.time,
-      endDateTime: endDate.time,
-    });
+    const eventBars = createEventBar(
+      {
+        standardDateTime: startDate.time,
+        endDateTime: endDate.time,
+      },
+      unitWeekDay,
+      firstStandardDate,
+    );
 
     eventBars.forEach(eventBar => {
       const key = eventBar.time;


### PR DESCRIPTION
## ⭐ Point <!-- 구현한 기능 혹은 목표에 대한 간략한 설명 -->
일/4일 단위 캘린더의 종일 이벤트 목록 표시

## 👨‍💻 작업 내용 <!-- 추가 설명이 필요한 경우 기입 -->
#### 일/4일 단위 캘린더의 종일 이벤트 목록 표시
- 주 단위 캘린더와 동일하게 표시

#### 이벤트바 생성 로직 수정
- 일/4일/주/월 단위 캘린더에서 동일한 로직을 사용할 수 있도록 수정

#### 이벤트바 UI 설정
- 캘린더 일정 기간을 넘어가는 이벤트인 경우, 화살표 이벤트바로 설정

![image](https://user-images.githubusercontent.com/52408122/192477679-bf0e1d85-14e2-4b12-8ffd-b670e07715e8.png)

<br/>

#### ⚡ Related Issues <!-- 관련된 이슈 번호 기입 -->
Closes #318
